### PR TITLE
Allow functions to be inlined

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1261,33 +1261,41 @@ pub trait AtMost128: IsNumber {}
 
 macro_rules! func {
 	( $name:ident ( self $(, $arg:ident : $t:ty)* ) $( -> $ret:ty )? ) => {
+		#[inline(always)]
 		fn $name ( self $(, $arg : $t )* ) $( -> $ret )? { <Self>:: $name ( self $(, $arg )* )}
 	};
 	( $name:ident ( &self $(, $arg:ident : $t:ty)* ) $( -> $ret:ty )? ) => {
+		#[inline(always)]
 		fn $name ( &self $(, $arg : $t )* ) $( -> $ret )? { <Self>:: $name ( &self $(, $arg )* )}
 	};
 	( $name:ident ( &mut self $(, $arg:ident : $t:ty)* ) $( -> $ret:ty )? ) => {
+		#[inline(always)]
 		fn $name ( &mut self $(, $arg : $t )* ) $( -> $ret )? { <Self>:: $name ( &mut self $(, $arg )* )}
 	};
 	( $name:ident ( $($arg:ident : $t:ty),* ) $( -> $ret:ty )? ) => {
+		#[inline(always)]
 		fn $name ( $($arg : $t ),* ) $( -> $ret )? { <Self>:: $name ( $( $arg ),* )}
 	};
 }
 
 macro_rules! stdfunc {
 	( $name:ident ( self $(, $arg:ident : $t:ty)* ) $( -> $ret:ty )? ) => {
+		#[inline(always)]
 		#[cfg(feature = "std")]
 		fn $name ( self $(, $arg : $t )* ) $( -> $ret )? { <Self>:: $name ( self $(, $arg )* )}
 	};
 	( $name:ident ( &self $(, $arg:ident : $t:ty)* ) $( -> $ret:ty )? ) => {
+		#[inline(always)]
 		#[cfg(feature = "std")]
 		fn $name ( &self $(, $arg : $t )* ) $( -> $ret )? { <Self>:: $name ( &self $(, $arg )* )}
 	};
 	( $name:ident ( &mut self $(, $arg:ident : $t:ty)* ) $( -> $ret:ty )? ) => {
+		#[inline(always)]
 		#[cfg(feature = "std")]
 		fn $name ( &mut self $(, $arg : $t )* ) $( -> $ret )? { <Self>:: $name ( &mut self $(, $arg )* )}
 	};
 	( $name:ident ( $($arg:ident : $t:ty),* ) $( -> $ret:ty )? ) => {
+		#[inline(always)]
 		#[cfg(feature = "std")]
 		fn $name ( $($arg : $t ),* ) $( -> $ret )? { <Self>:: $name ( $( $arg ),* )}
 	};


### PR DESCRIPTION
I noticed that functions in this crate aren't being inlined in generated code, which comes with a severe performance penalty given how tiny some of these functions are. This PR adds `#[inline(always)]` annotations to the trait implementations to prevent this from happening. 

I also noticed that funty 2.0 hasn't yet been pushed to GitHub, so this PR is against version 1.2. Given how commonly older versions of funty are used in the wild (based on crates.io download stats) and also the performance implications, this fix should _probably_ be backported to 1.1, 1.2, and 2.0 branches.
